### PR TITLE
Fixed loading display style

### DIFF
--- a/.changeset/spotty-dolphins-flow.md
+++ b/.changeset/spotty-dolphins-flow.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Fixed display style of tabs being different when loaded.

--- a/src/templates/clip-page-loading.tsx
+++ b/src/templates/clip-page-loading.tsx
@@ -5,7 +5,7 @@ import { Center, Loading, Tab, TabList, Tabs } from "@yamada-ui/react"
 export function ClipPageLoading() {
   return (
     <AppLayout>
-      <Tabs align="center">
+      <Tabs align="center" index={0}>
         <TabList>
           {PERIODS.trend.map((tab) => (
             <Tab


### PR DESCRIPTION

## Description

<!-- Add a brief description. -->
Fixed display style of tabs being different when loaded.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
