### PR TITLE
Added tooltip to clip tile

### DIFF
--- a/.changeset/moody-ducks-bake.md
+++ b/.changeset/moody-ducks-bake.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Added tooltip to title of `ClipCard` in side clip list.

--- a/src/components/data-display/side-clip-list.tsx
+++ b/src/components/data-display/side-clip-list.tsx
@@ -25,6 +25,7 @@ import {
   Separator,
   Spacer,
   Text,
+  TextProps,
   Tooltip,
   useWindowEvent,
   VStack,
@@ -62,6 +63,18 @@ function ClipCard({ clip, tab }: ClipCardProps) {
     })
   }
 
+  //NOTE: declare as `any` type because `error TS2590: Expression produces a union type that is too complex to represent.` occurred.
+  const tooltipProps: any = {
+    label: title,
+    placement: "top-start",
+  }
+
+  const textProps: TextProps = {
+    fontWeight: "bold",
+    isTruncated: true,
+    onClick,
+  }
+
   return (
     <VStack gap="1" w="full">
       <Container
@@ -86,9 +99,9 @@ function ClipCard({ clip, tab }: ClipCardProps) {
         />
 
         <VStack gap={0} overflow="hidden" w="full">
-          <Text fontWeight="bold" isTruncated onClick={onClick}>
-            {title}
-          </Text>
+          <Tooltip {...tooltipProps}>
+            <Text {...textProps}>{title}</Text>
+          </Tooltip>
 
           <HStack>
             <Text


### PR DESCRIPTION

## Description

<!-- Add a brief description. -->
Added tooltip to clip tile in side clip list.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
`Tooltip` has type bug.