### PR TITLE
Fixed wrong ga event

### DIFF
--- a/.changeset/light-carrots-guess.md
+++ b/.changeset/light-carrots-guess.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Fixed reverse ga label of click favorite.

--- a/src/components/form/favorite-button.tsx
+++ b/src/components/form/favorite-button.tsx
@@ -46,7 +46,7 @@ export function FavoriteButton({ clip }: FavoriteButtonProps) {
 
         sendGAEvent("event", "click", {
           clip_title: title,
-          label: "add_to_favorite",
+          label: "remove_to_favorite",
         })
       } else {
         await saveClip(clip)
@@ -54,7 +54,7 @@ export function FavoriteButton({ clip }: FavoriteButtonProps) {
 
         sendGAEvent("event", "click", {
           clip_title: title,
-          label: "remove_from_favorite",
+          label: "add_from_favorite",
         })
       }
 


### PR DESCRIPTION

## Description

<!-- Add a brief description. -->
Fixed reverse ga label of click favorite.
## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
Send GA `remove_from_favorite` when added favorite and `add_to_favorite` when removed favorite.


## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
