### PR TITLE
Added `SkeletonAvatar`

### DIFF
--- a/.changeset/rude-humans-listen.md
+++ b/.changeset/rude-humans-listen.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Added `SkeletonAvatar` and replaced `Avatar`.

--- a/src/components/data-display/channel-card.tsx
+++ b/src/components/data-display/channel-card.tsx
@@ -1,8 +1,7 @@
-import { TwitchLink } from "@/components/media-and-icons"
+import { SkeletonAvatar, TwitchLink } from "@/components/media-and-icons"
 import { Streamer } from "@/models/streamer"
 import { GhostIcon } from "@yamada-ui/lucide"
 import {
-  Avatar,
   Heading,
   HStack,
   LinkBox,
@@ -32,7 +31,7 @@ export function ChannelCard({ streamer }: ChannelCardProps) {
   return (
     <LinkBox apply="layoutStyles.borderCard" as="article" p="sm">
       <HStack gap={2} w="full">
-        <Avatar
+        <SkeletonAvatar
           alt={display_name}
           icon={<GhostIcon />}
           src={profile_image_url}

--- a/src/components/data-display/clip-grid.tsx
+++ b/src/components/data-display/clip-grid.tsx
@@ -7,7 +7,6 @@ import { sendGAEvent } from "@next/third-parties/google"
 import { GhostIcon, SquareArrowOutUpRightIcon } from "@yamada-ui/lucide"
 import {
   AspectRatio,
-  Avatar,
   Container,
   For,
   GridItem,
@@ -22,6 +21,8 @@ import {
   VStack,
 } from "@yamada-ui/react"
 import Link from "next/link"
+
+import { SkeletonAvatar } from "../media-and-icons"
 
 interface ClipCardProps {
   clip: Clip
@@ -78,7 +79,7 @@ function ClipCard({ clip }: ClipCardProps) {
       </Container>
 
       <HStack>
-        <Avatar
+        <SkeletonAvatar
           alt={broadcaster_name}
           as={Link}
           href={`/streamer/${broadcaster_id}`}

--- a/src/components/data-display/clip-list-tabs.tsx
+++ b/src/components/data-display/clip-list-tabs.tsx
@@ -11,8 +11,6 @@ import { SquareArrowOutUpRightIcon } from "@yamada-ui/lucide"
 import {
   AspectRatio,
   assignRef,
-  Avatar,
-  AvatarProps,
   Box,
   Container,
   Heading,
@@ -22,30 +20,18 @@ import {
   InfiniteScrollArea,
   isArray,
   Loading,
-  SkeletonCircle,
   Spacer,
   Tab,
   TabList,
   Tabs,
   TabsProps,
   Text,
-  useBoolean,
   VStack,
 } from "@yamada-ui/react"
 import Link from "next/link"
 import { RefObject, useMemo, useRef, useState } from "react"
 
-interface UIAvatarProps extends AvatarProps {}
-
-function UIAvatar(props: UIAvatarProps) {
-  const [avatarLoaded, { on: avatarOn }] = useBoolean()
-
-  return (
-    <SkeletonCircle isLoaded={avatarLoaded}>
-      <Avatar onLoad={avatarOn} {...props} />
-    </SkeletonCircle>
-  )
-}
+import { SkeletonAvatar } from "../media-and-icons"
 
 interface ClipCardProps {
   clip: Clip
@@ -128,7 +114,7 @@ function ClipCard({ clip, tab }: ClipCardProps) {
             }}
             w="fit-content"
           >
-            <UIAvatar
+            <SkeletonAvatar
               alt={broadcaster_name}
               size={{ base: "base", sm: "sm" }}
               src={profile_image_url}

--- a/src/components/data-display/side-clip-list.tsx
+++ b/src/components/data-display/side-clip-list.tsx
@@ -10,7 +10,6 @@ import { AlignJustifyIcon, GhostIcon } from "@yamada-ui/lucide"
 import {
   AspectRatio,
   assignRef,
-  Avatar,
   Box,
   Button,
   ButtonProps,
@@ -32,6 +31,8 @@ import {
 } from "@yamada-ui/react"
 import Link from "next/link"
 import { RefObject, useMemo, useRef, useState } from "react"
+
+import { SkeletonAvatar } from "../media-and-icons"
 
 interface ClipCardProps {
   clip: Clip
@@ -78,7 +79,7 @@ function ClipCard({ clip, tab }: ClipCardProps) {
       </Container>
 
       <HStack>
-        <Avatar
+        <SkeletonAvatar
           alt={broadcaster_name}
           as={Link}
           href={`/streamer/${broadcaster_id}`}

--- a/src/components/data-display/streamer-card.tsx
+++ b/src/components/data-display/streamer-card.tsx
@@ -1,7 +1,7 @@
-import { TwitchLink } from "@/components/media-and-icons"
+import { SkeletonAvatar, TwitchLink } from "@/components/media-and-icons"
 import { Streamer } from "@/models/streamer"
 import { GhostIcon } from "@yamada-ui/lucide"
-import { Avatar, Heading, HStack, Spacer, Text, VStack } from "@yamada-ui/react"
+import { Heading, HStack, Spacer, Text, VStack } from "@yamada-ui/react"
 import Link from "next/link"
 
 interface StreamerCardProps {
@@ -22,7 +22,7 @@ export function StreamerCard({ streamer }: StreamerCardProps) {
 
   return (
     <HStack gap={2} justifyContent="flex-start" w="full">
-      <Avatar
+      <SkeletonAvatar
         alt={display_name}
         aria-label="streamer page link"
         as={Link}

--- a/src/components/data-display/streamer-info.tsx
+++ b/src/components/data-display/streamer-info.tsx
@@ -1,8 +1,8 @@
 "use client"
-import { TwitchLink } from "@/components/media-and-icons"
+import { SkeletonAvatar, TwitchLink } from "@/components/media-and-icons"
 import { useClip } from "@/contexts"
 import { GhostIcon } from "@yamada-ui/lucide"
-import { Avatar, HStack, Spacer, Text, VStack } from "@yamada-ui/react"
+import { HStack, Spacer, Text, VStack } from "@yamada-ui/react"
 import Link from "next/link"
 
 export function StreamerInfo() {
@@ -20,7 +20,7 @@ export function StreamerInfo() {
 
   return (
     <HStack>
-      <Avatar
+      <SkeletonAvatar
         alt={broadcaster_name}
         as={Link}
         href={`/streamer/${broadcaster_id}`}

--- a/src/components/media-and-icons/index.ts
+++ b/src/components/media-and-icons/index.ts
@@ -1,3 +1,4 @@
 export * from "./hexagon-outlined"
+export * from "./skeleton-avatar"
 export * from "./twitch-link"
 export * from "./x"

--- a/src/components/media-and-icons/skeleton-avatar.tsx
+++ b/src/components/media-and-icons/skeleton-avatar.tsx
@@ -1,0 +1,18 @@
+import {
+  Avatar,
+  AvatarProps,
+  SkeletonCircle,
+  useBoolean,
+} from "@yamada-ui/react"
+
+interface SkeletonAvatarProps extends AvatarProps {}
+
+export function SkeletonAvatar(props: SkeletonAvatarProps) {
+  const [avatarLoaded, { on: avatarOn }] = useBoolean()
+
+  return (
+    <SkeletonCircle isLoaded={avatarLoaded}>
+      <Avatar onLoad={avatarOn} {...props} />
+    </SkeletonCircle>
+  )
+}


### PR DESCRIPTION
Closes #342

## Description

<!-- Add a brief description. -->
Added `SkeletonAvatar` and `Avatar` is replaced to that.
`SkeletonAvatar` display `Skeleton` during loading.


## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
