### PR TITLE
fix: ga debug mode

### DIFF
--- a/.changeset/wise-cameras-sin.md
+++ b/.changeset/wise-cameras-sin.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Fixed ga debug mode.

--- a/src/utils/google-analytics.tsx
+++ b/src/utils/google-analytics.tsx
@@ -43,7 +43,7 @@ export function GoogleAnalytics({
           gtag('js', new Date());
 
           gtag('config', '${gaId}' ,{
-            'debug_mode': ${debugMode},
+            ${debugMode ? "'debug_mode': true," : ""}
             'display_mode': '${displayMode}'
           });`,
         }}


### PR DESCRIPTION
Related #353

## Description

<!-- Add a brief description. -->
Fixed ga debug mode is on when exist `debugMode` parameter ethier value is `false`.
If it is not debug mode, the `debugMode` parameter must be removed.
## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
All access is `debugMode`.


## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
