### PR TITLE
Fixed GoogleAnalytics event was not send

### DIFF
--- a/.changeset/friendly-meals-bow.md
+++ b/.changeset/friendly-meals-bow.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Fixed ga event was not send.

--- a/src/utils/google-analytics.tsx
+++ b/src/utils/google-analytics.tsx
@@ -69,14 +69,16 @@ export function GoogleAnalytics({
   )
 }
 
-export function sendGAEvent(...args: any[]) {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function sendGAEvent(..._args: any[]) {
   if (currDataLayerName === undefined) {
     console.warn(`@next/third-parties: GA has not been initialized`)
     return
   }
 
   if (window[currDataLayerName]) {
-    window[currDataLayerName].push(...args)
+    // eslint-disable-next-line prefer-rest-params
+    window[currDataLayerName].push(arguments)
   } else {
     console.warn(
       `@next/third-parties: GA dataLayer ${currDataLayerName} does not exist`,


### PR DESCRIPTION
Related #353

## Description

<!-- Add a brief description. -->
GoogleAnalytics event was not send when `sendGAEvent` is triggered.
## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
This statement will push each argument, but arguments must be an object.
```tsx
window[currDataLayerName].push(...args)
```
## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
Arguments will be pushed as an object.
```tsx
window[currDataLayerName].push(arguments)
```
## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
