### PR TITLE
Updated mobile ad display position

### DIFF
--- a/.changeset/new-mayflies-sell.md
+++ b/.changeset/new-mayflies-sell.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Updated ad display position.

--- a/src/components/data-display/clip-list-tabs.tsx
+++ b/src/components/data-display/clip-list-tabs.tsx
@@ -209,6 +209,8 @@ function ClipList({
   const breakpoint = useBreakpoint()
   const resetRef = useRef<() => void>(() => {})
 
+  const isFirstTab = tabIndex == 0
+
   function resetCount() {
     if (window) window.scrollTo({ top: 0 })
 
@@ -222,21 +224,22 @@ function ClipList({
     () =>
       clips.slice(0, count).map((clip, index) => {
         const isDisplayIndex =
-          (index == 4 && tabIndex == 0) ||
-          (index == CLIP_LIST.START_INDEX && tabIndex != 0)
+          (isFirstTab && index == 3) ||
+          (isFirstTab && index == clips.length - 1 && clips.length <= 3) ||
+          (!isFirstTab && index == CLIP_LIST.START_INDEX)
 
         if (isDisplayIndex && breakpoint == "sm") {
           return (
             <Box key={index}>
-              <InlineAD />
               <ClipCard clip={clip} tab={tab} />
+              <InlineAD />
             </Box>
           )
         } else {
           return <ClipCard clip={clip} key={index} tab={tab} />
         }
       }),
-    [breakpoint, clips, count, tab, tabIndex],
+    [breakpoint, clips, count, isFirstTab, tab],
   )
 
   return (


### PR DESCRIPTION

## Description

<!-- Add a brief description. -->
Updated ad display position to display last of clips when first tab clips has 3 or less clips.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
