### PR TITLE
Fixed scroll area

### DIFF
--- a/.changeset/wicked-suns-crash.md
+++ b/.changeset/wicked-suns-crash.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Fixed infinite scroll works instability.

--- a/src/theme/styles/layer-styles.ts
+++ b/src/theme/styles/layer-styles.ts
@@ -30,16 +30,4 @@ export const layerStyles: LayerStyles = {
     overflow: "hidden",
     transition: "0.2s ease",
   },
-  scrollArea: {
-    _scrollbar: {
-      display: "auto",
-      width: "1.5",
-    },
-    _scrollbarThumb: {
-      bg: "gray.500",
-      borderRadius: "full",
-    },
-    overflowY: "scroll",
-    p: 0,
-  },
 }

--- a/src/ui/components/data-display/side-clip-list.tsx
+++ b/src/ui/components/data-display/side-clip-list.tsx
@@ -19,6 +19,7 @@ import {
   Loading,
   NativeImage,
   noop,
+  ScrollArea,
   Select,
   SelectItem,
   Separator,
@@ -165,7 +166,7 @@ function ClipList({ clips, resetRef: resetRefProp, tab }: ClipListProps) {
   )
 
   return (
-    <Container layerStyle="scrollArea" maxH={height} ref={rootRef}>
+    <ScrollArea h={height} ref={rootRef}>
       <InfiniteScrollArea
         finish={<EmptyState title="No more clips" />}
         loading={<Loading fontSize="2xl" />}
@@ -185,7 +186,7 @@ function ClipList({ clips, resetRef: resetRefProp, tab }: ClipListProps) {
       >
         {filteredClips}
       </InfiniteScrollArea>
-    </Container>
+    </ScrollArea>
   )
 }
 

--- a/src/ui/components/data-display/side-clip-list.tsx
+++ b/src/ui/components/data-display/side-clip-list.tsx
@@ -5,7 +5,7 @@ import { Clip } from "@/models/clip"
 import { getTabs } from "@/utils/clip"
 import { sendGAEvent } from "@/utils/google-analytics"
 import { formatDate } from "@/utils/string"
-import { AlignJustifyIcon, GhostIcon } from "@yamada-ui/lucide"
+import { ArrowLeftIcon, GhostIcon } from "@yamada-ui/lucide"
 import {
   AspectRatio,
   assignRef,
@@ -144,8 +144,8 @@ function ClipList({ clips, resetRef: resetRefProp, tab }: ClipListProps) {
   })
 
   function resetCount() {
-    resetRef.current()
     setCount(CLIP_LIST.START_INDEX)
+    resetRef.current()
   }
 
   assignRef(resetRefProp, resetCount)
@@ -223,7 +223,7 @@ export function SideClipTabs() {
         <Tooltip label="リスト表示にもどる" placement="top">
           <Button
             onClick={handleClick}
-            startIcon={<AlignJustifyIcon />}
+            startIcon={<ArrowLeftIcon />}
             variant="link"
           >
             clips


### PR DESCRIPTION
Closes #217 

## Description

<!-- Add a brief description. -->
Use `ScrollArea` component in infinite scroll instead of `Container`.
## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
