### PR TITLE
Animation of navigation items

### DIFF
--- a/.changeset/floppy-bugs-try.md
+++ b/.changeset/floppy-bugs-try.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Added animation for hovered navigation item.

--- a/src/theme/styles/layer-styles.ts
+++ b/src/theme/styles/layer-styles.ts
@@ -16,6 +16,33 @@ export const layerStyles: LayerStyles = {
     overflow: "hidden",
     transition: "0.2s ease",
   },
+  navigation: {
+    _before: {
+      bg: "$bg",
+      borderRadius: "md",
+      height: "anchor-size(--hover height)",
+      left: "anchor(--hover left)",
+      pointerEvents: "none",
+      position: "absolute",
+      top: "anchor(--hover top)",
+      transitionDuration: "slow",
+      transitionProperty: "left, width",
+      transitionTimingFunction: "ease",
+      width: "anchor-size(--hover width)",
+    },
+    vars: [
+      {
+        name: "bg",
+        token: "colors",
+        value: ["blackAlpha.200", "whiteAlpha.200"],
+      },
+    ],
+  },
+  navigationItem: {
+    _focus: { outline: "none" },
+    _focusVisible: { "anchor-name": "--hover" },
+    _hover: { "anchor-name": "--hover" },
+  },
   player: {
     _active: {
       borderColor: "primary.500",

--- a/src/theme/styles/text-styles.ts
+++ b/src/theme/styles/text-styles.ts
@@ -25,6 +25,9 @@ export const textStyles: TextStyles = {
     minW: "4xs",
   },
   navigation: {
+    _focusVisible: {
+      color: ["black", "white"],
+    },
     _hover: {
       color: ["black", "white"],
     },

--- a/src/ui/components/layouts/header.tsx
+++ b/src/ui/components/layouts/header.tsx
@@ -73,11 +73,17 @@ export function Header(props: HeaderProps) {
           borderColor={["blackAlpha.300", "whiteAlpha.300"]}
           display={{ base: "flex", md: "none" }}
           h="7xs"
-          marginX="lg"
+          marginLeft="lg"
+          marginRight="md"
           orientation="vertical"
         />
 
-        <HStack as="nav" display={{ base: "flex", md: "none" }} gap="lg">
+        <HStack
+          as="nav"
+          display={{ base: "flex", md: "none" }}
+          gap={0}
+          layerStyle="navigation"
+        >
           {CONSTANT.PATHS.map(({ href, title, tooltip }) => (
             <Tooltip key={title} label={tooltip}>
               <Text
@@ -86,6 +92,9 @@ export function Header(props: HeaderProps) {
                 data-selected={dataAttr(pathname === href)}
                 href={href}
                 isTruncated
+                layerStyle="navigationItem"
+                px="md"
+                py="xs"
                 textStyle="navigation"
               >
                 {title}


### PR DESCRIPTION

## Description

<!-- Add a brief description. -->
Added hover animation for navigation items.
`before` element is display behind item when item is hovered.