### PR TITLE
Fixed `CarouselItem` stretch over screen width

### DIFF
--- a/.changeset/evil-bushes-try.md
+++ b/.changeset/evil-bushes-try.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Fixed first `Carousel` item component is stretch over screen width. Horizontal padding is needed to prevent bugs.

--- a/src/ui/components/data-display/clip-list-tabs.tsx
+++ b/src/ui/components/data-display/clip-list-tabs.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { Carousel, CarouselSlide } from "@yamada-ui/carousel"
+import { Carousel, CarouselProps, CarouselSlide } from "@yamada-ui/carousel"
 import {
   PlayIcon,
   SquareArrowOutUpRightIcon,
@@ -404,10 +404,15 @@ function ClipList({
 }
 
 interface ClipListTabProps extends TabsProps {
+  carouselProps?: CarouselProps
   withTab?: boolean
 }
 
-export function ClipListTabs({ withTab = true, ...rest }: ClipListTabProps) {
+export function ClipListTabs({
+  carouselProps,
+  withTab = true,
+  ...rest
+}: ClipListTabProps) {
   const { clipDoc } = useClip()
   const [index, onChange] = useState(0)
 
@@ -467,6 +472,7 @@ export function ClipListTabs({ withTab = true, ...rest }: ClipListTabProps) {
         loop={false}
         withControls={false}
         withIndicators={false}
+        {...carouselProps}
       >
         {tabs.map((tab, index) => {
           const clips = clipDoc?.[tab]

--- a/src/ui/components/layouts/mobile-view.tsx
+++ b/src/ui/components/layouts/mobile-view.tsx
@@ -31,7 +31,7 @@ export function MobileView() {
   useWindowEvent("resize", () => setWidth(window?.innerWidth))
 
   return (
-    <VStack gap={1}>
+    <VStack as="main" gap={1}>
       <Player
         embedUrl={currentClip?.embed_url}
         position="sticky"

--- a/src/ui/components/layouts/mobile-view.tsx
+++ b/src/ui/components/layouts/mobile-view.tsx
@@ -19,6 +19,9 @@ export function MobileView() {
       backdropBlur: "50px",
       backdropFilter: "auto",
       bg: isScroll ? ["whiteAlpha.700", "blackAlpha.700"] : undefined,
+      carouselProps: {
+        px: "xs",
+      },
       position: "sticky",
       ref: tabsRef,
       shadow: isScroll ? ["base", "dark-sm"] : undefined,

--- a/src/ui/components/layouts/pc-view.tsx
+++ b/src/ui/components/layouts/pc-view.tsx
@@ -8,6 +8,7 @@ export function PCView() {
 
   return (
     <Grid
+      as="main"
       gap={{ "2xl": "xl", base: "3xl", xl: "lg" }}
       marginX={{ "2xl": "xl", base: "3xl", xl: "lg" }}
       templateColumns="repeat(12, 1fr)"


### PR DESCRIPTION
Closes #556 

## Description

<!-- Add a brief description. -->
Fixed `CarouselItem` stretch over screen width in mobile view.
This is because `Carousel` has no horizontal padding.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
Added padding to `Carousel` in mobile view.
## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
