### PR TITLE
Updated global style

### DIFF
--- a/.changeset/fancy-trams-grin.md
+++ b/.changeset/fancy-trams-grin.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip": patch
+---
+
+Prevent to select element, when longpress on ios.

--- a/src/theme/styles/global-style.ts
+++ b/src/theme/styles/global-style.ts
@@ -11,5 +11,6 @@ export const globalStyle: UIStyle = {
       borderRadius: "full",
     },
     bg: ["white", "black"],
+    userSelect: "none",
   },
 }

--- a/src/ui/components/data-display/clip-list-tabs.tsx
+++ b/src/ui/components/data-display/clip-list-tabs.tsx
@@ -256,6 +256,10 @@ function ClipCard({ clip, tab }: ClipCardProps) {
             ranking_period: tab,
           })
         }}
+        onContextMenu={(ev: MouseEvent) => {
+          ev.preventDefault()
+          ev.stopPropagation()
+        }}
         onTouchEnd={onTouchEnd}
         onTouchMove={onTouchEnd}
         onTouchStart={onTouchStart}


### PR DESCRIPTION
Closes #565 

## Description

<!-- Add a brief description. -->
Prevent to select element, when longpress on ios.
Added `user-select: "none"` in global style.
## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
Element select when longpress clip card in ios.
## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No